### PR TITLE
Add 837 Testing Module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 all:
 	$(MAKE) -C lib
 
+.PHONY: tests
+tests:
+	$(MAKE) -C tests
+
 .PHONY: clean
 clean:
 	$(MAKE) clean -C lib
+	$(MAKE) clean -C tests

--- a/tests/005010X222A1.c
+++ b/tests/005010X222A1.c
@@ -1,0 +1,155 @@
+
+#include <string.h>
+#include "005010X222A1.h"
+
+static inline void x12_fwrite_seg(EDISegment* seg, FILE* output) {
+
+    const char* cursor = seg->cursor;
+    const size_t n = seg->offset[MAX_N_ELEM - 1] + 1;
+    fwrite(cursor, 1, n, output);
+
+}
+
+static inline void x12_fwrite_str(X12Stream* str) {
+
+    if (str->skip) { str->skip = 0; }
+    else if (str->inject) { x12_fwrite_seg(str->seg, str->output); }
+
+    if (str->loop < 2400) { str->inject = 0; }
+    else if (str->loop > 2420) { str->skip = 1; }
+    else { /* still inside service line loop */ }
+
+}
+
+static inline int x12_memcmp_element(EDISegment* seg, int n, char* s) {
+
+    size_t size = strlen(s);
+    return edi_memcmp_element(seg, n, s, size);
+
+}
+
+static X12Status x12_parse_segment(EDISegment* seg, X12Stream* str) {
+
+    switch (seg->type) {
+
+    case X12_SEGMENT_GS:
+
+        str->loop = 0;
+
+        if (x12_memcmp_element(seg, 7, "005010X222A1") == 0) { break; }
+        else { return X12_UNKNOWN_RELEASE; }
+
+    case X12_SEGMENT_ST:
+        
+        str->loop = 1000;
+
+        x12_fwrite_str(str);
+        break;
+
+    case X12_SEGMENT_NM1:
+
+        if (x12_memcmp_element(seg, 0, "DN") != 0) { break; }
+        else if (str->loop >= 2400) { str->skip = 1; break; }
+        else if (str->loop <  2300) { return X12_ILLEGAL_SEGMENT; }
+
+        memcpy(str->seg, seg, sizeof(EDISegment));
+        str->inject = 1;
+        str->skip = 1;
+        break;
+
+    case X12_SEGMENT_LQ:
+
+        if (str->loop < 2400) { return X12_ILLEGAL_SEGMENT; }
+        else { str->loop = 2440; }
+
+        x12_fwrite_str(str);
+        break;
+
+    case X12_SEGMENT_SVD:
+
+        if (str->loop < 2400) { return X12_ILLEGAL_SEGMENT; }
+        else { str->loop = 2430; }
+
+        x12_fwrite_str(str);
+        break;
+
+    case X12_SEGMENT_LX:
+
+        str->loop = 2400;
+
+        x12_fwrite_str(str);
+        break;
+
+    case X12_SEGMENT_CLM:
+
+        str->loop = 2300;
+
+        x12_fwrite_str(str);
+        break;
+
+    case X12_SEGMENT_HL:
+
+        // TODO: use precise loop number
+        str->loop = 2000;
+
+        x12_fwrite_str(str);
+        break;
+
+    case X12_SEGMENT_SE:
+
+        str->loop = 1000;
+
+        x12_fwrite_str(str);
+        break;
+
+    case X12_SEGMENT_GE:
+
+        str->loop = 0;
+        break;
+
+    default:
+        break;
+
+    }
+
+    x12_fwrite_seg(seg, str->output);
+    return X12_OK;
+
+}
+
+static X12Status x12_parse_file(EDIFile* edi, X12Stream* str) {
+
+    EDISegment* seg = NULL;
+
+    while (edi_next_segment(edi, &seg) == EDI_OK) {
+        
+        X12Status s = x12_parse_segment(seg, str);
+
+        if (s != X12_OK) { return s; }
+        else { continue; }
+        
+    }
+
+    return X12_OK;
+
+}
+
+int main(int argc, char** argv) {
+
+    if (argc < 2) {
+        
+        printf("missing input file\n");
+        return EXIT_FAILURE;
+        
+    } else {
+
+        EDIFile* edi = EDI_FILE_INIT(argv[1], EDI_X12);
+        X12Stream* str = X12_STREAM_AUTO(stdout);
+        X12Status s = x12_parse_file(edi, str);
+        EDI_FILE_FREE(edi);
+
+        return s;
+
+    }
+
+}

--- a/tests/005010X222A1.c
+++ b/tests/005010X222A1.c
@@ -76,6 +76,7 @@ static X12Status x12_parse_segment(EDISegment* seg, X12Stream* str) {
     case X12_SEGMENT_LX:
 
         str->loop = 2400;
+        if (str->inject) { str->seg->cursor[5] = 'K'; }
 
         x12_fwrite_str(str);
         break;

--- a/tests/005010X222A1.h
+++ b/tests/005010X222A1.h
@@ -1,0 +1,35 @@
+
+#ifndef BARE_BONES_EDI_005010X222A1_H
+#define BARE_BONES_EDI_005010X222A1_H
+
+#include <stdio.h>
+#include "reader.h"
+
+typedef enum {
+
+    X12_OK,
+    X12_ILLEGAL_SEGMENT,
+    X12_UNKNOWN_RELEASE,
+
+} X12Status;
+
+typedef struct {
+
+    EDISegment* seg;
+    FILE* output;
+    int inject;
+    int skip;
+    int loop;
+
+} X12Stream;
+
+#define X12_STREAM_AUTO(X) &(X12Stream) \
+{                                       \
+    .seg = EDI_COMPOSITE_AUTO(),        \
+    .output = X,                        \
+    .inject = 0,                        \
+    .skip = 0,                          \
+    .loop = 0                           \
+}
+
+#endif

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 
-src = $(wildcard *.c)
+src = 005010X222A1.c
 obj = $(src:.c=.o)
-bin = 005010X221A1
+bin = 005010X222A1
 
 CC = gcc
 CFLAGS = -std=c17 -O2 -Wall -Wextra -I../lib

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,15 +1,16 @@
 
-src = 005010X222A1.c
-obj = $(src:.c=.o)
-bin = 005010X222A1
-
 CC = gcc
 CFLAGS = -std=c17 -O2 -Wall -Wextra -I../lib
 LDFLAGS = -L../lib -ledi
 
-$(bin): $(obj)
+all: 005010X221A1 005010X222A1
+
+005010X221A1: 005010X221A1.o
+	$(CC) $^ -o $@ $(LDFLAGS)
+
+005010X222A1: 005010X222A1.o
 	$(CC) $^ -o $@ $(LDFLAGS)
 
 .PHONY: clean
 clean:
-	rm $(bin) $(obj)
+	rm 005010X221A1 005010X222A1 *.o


### PR DESCRIPTION
This testing program will take an input file (X12 837) and inject an ordering physician segment for each service line, wherever a referring provider segment is present at the claim level.